### PR TITLE
With requires two brackets

### DIFF
--- a/docs/language/api.rst
+++ b/docs/language/api.rst
@@ -1400,18 +1400,18 @@ manner. The archetypical example of using ``with`` is when processing files.
 
 .. code-block:: clj
 
-    (with [arg (expr)] block)
+    (with [[arg (expr) ...]] block)
 
-    (with [(expr)] block)
+    (with [[(expr)]] block)
 
-    (with [arg (expr) (expr)] block)
+    (with [[arg (expr) (expr)]] block)
 
 The following example will open the ``NEWS`` file and print its content to the
 screen. The file is automatically closed after it has been processed.
 
 .. code-block:: clj
 
-    (with [f (open "NEWS")] (print (.read f)))
+    (with [[f (open "NEWS")]] (print (.read f)))
 
 
 with-decorator


### PR DESCRIPTION
The example in the documentation would generate an error saying that `f` is not a global variable. Hy uses two brackets for `with`.